### PR TITLE
Fix typo in Volotea doctype 

### DIFF
--- a/declarations/Volotea.json
+++ b/declarations/Volotea.json
@@ -1,7 +1,7 @@
 {
   "name": "Volotea",
   "documents": {
-    "Condition of Carriage": {
+    "Conditions of Carriage": {
       "fetch": "https://www.volotea.com/fr/conditions-legales/conditions-de-transport/",
       "select": ".v7-section__content",
       "remove": "a[href=\"#main\"]"


### PR DESCRIPTION
Introduced in #232.

Tests had caught that error but branch protection was not enabled, letting this problem pass 🙁

We should thus clean the history of this wrong doctype.