### PR TITLE
Fix #376: Fix Lime - Terms of Service

### DIFF
--- a/declarations/Lime.json
+++ b/declarations/Lime.json
@@ -4,7 +4,7 @@
     "Terms of Service": {
       "fetch": "https://www.li.me/fr-fr/user-agreement",
       "select": "main",
-      "remove": "img[src=\"https://www.li.me/hubfs/Assets/icon-email.png\"]"
+      "remove": "ul.rounded-full"
     },
     "Privacy Policy": {
       "fetch": "https://www.li.me/fr/legal/privacy-policy/",

--- a/declarations/Lime.json
+++ b/declarations/Lime.json
@@ -3,7 +3,7 @@
   "documents": {
     "Terms of Service": {
       "fetch": "https://www.li.me/fr-fr/user-agreement",
-      "select": "#francefrance",
+      "select": "main",
       "remove": "img[src=\"https://www.li.me/hubfs/Assets/icon-email.png\"]"
     },
     "Privacy Policy": {

--- a/declarations/Lime.json
+++ b/declarations/Lime.json
@@ -2,7 +2,7 @@
   "name": "Lime",
   "documents": {
     "Terms of Service": {
-      "fetch": "https://www.li.me/user-agreement/fr",
+      "fetch": "https://www.li.me/fr-fr/user-agreement",
       "select": "#francefrance",
       "remove": "img[src=\"https://www.li.me/hubfs/Assets/icon-email.png\"]"
     },

--- a/declarations/Lime.json
+++ b/declarations/Lime.json
@@ -3,8 +3,9 @@
   "documents": {
     "Terms of Service": {
       "fetch": "https://www.li.me/fr-fr/user-agreement",
-      "select": "main",
-      "remove": "ul.rounded-full"
+      "select": ["main"],
+      "remove": "ul.rounded-full",
+      "executeClientScripts": true
     },
     "Privacy Policy": {
       "fetch": "https://www.li.me/fr/legal/privacy-policy/",


### PR DESCRIPTION
- Fix Lime - Terms of Service:new URL and new CSS selector
- improvement: fix the Lime email address in Terms of Service (with option `executeClientScripts`)