### PR TITLE
Fix #272 : Fix error 403 on Amazon Music website

### DIFF
--- a/declarations/Amazon Music.json
+++ b/declarations/Amazon Music.json
@@ -3,7 +3,8 @@
   "documents": {
     "Terms of Service": {
       "fetch": "https://www.amazon.fr/gp/help/customer/display.html?pop-up=1&nodeId=201380010&language=fr_FR",
-      "select": [".help-service-content"]
+      "select": [".help-service-content"],
+      "executeClientScripts": true
     }
   }
 }


### PR DESCRIPTION
Details:
Set executeClientScripts to avoid HTTP error 403 in Amazon Music website