### PR TITLE
Add a bunch of car manufacturers and car apps

### DIFF
--- a/declarations/BMW Group.json
+++ b/declarations/BMW Group.json
@@ -1,0 +1,8 @@
+{
+  "name": "BMW Group",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://customer.bmwgroup.com/pm2/pm-document-service/api/v1link/documents/policyName/MY_BMW_APP_DPP/FR/PDF?language=fr&KeyId=31c357a0-7a1d-4590-aa99-33b97244d048"
+    }
+  }
+}

--- a/declarations/Fiat.json
+++ b/declarations/Fiat.json
@@ -1,0 +1,12 @@
+{
+  "name": "Fiat",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://www.fiat.fr/contacts/protection-des-donnees",
+      "select": {
+        "startBefore": "h1",
+        "endBefore": ".social-footer-wrap"
+      }
+    }
+  }
+}

--- a/declarations/FordPass.json
+++ b/declarations/FordPass.json
@@ -1,0 +1,19 @@
+{
+  "name": "FordPass",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://www.fordpass.com/content/ford_com/fp_app/fr_fr/privacy.html",
+      "select": {
+        "startAfter": "a",
+        "endAfter": ".richText-component"
+      }
+    },
+    "Terms of Service": {
+      "fetch": "https://www.fordpass.com/content/ford_com/fp_app/fr_fr/terms.html",
+      "select": {
+        "startAfter": "a",
+        "endAfter": ".richText-component"
+      }
+    }
+  }
+}

--- a/declarations/Kia Connect.json
+++ b/declarations/Kia Connect.json
@@ -1,0 +1,19 @@
+{
+  "name": "Kia Connect",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://connect.kia.com/lu/kia-connect-privacy-notice/",
+      "select": {
+        "startAfter": ".eut_cmpe_btn",
+        "endAfter": "div.par.parsys"
+      }
+    },
+    "Terms of Service": {
+      "fetch": "https://connect.kia.com/fr/kia-connect-legal-document1/",
+      "select": {
+        "startAfter": ".eut_cmpe_btn",
+        "endAfter": "div.par.parsys"
+      }
+    }
+  }
+}

--- a/declarations/My Audi.json
+++ b/declarations/My Audi.json
@@ -1,0 +1,12 @@
+{
+  "name": "My Audi",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://www.audi.fr/fr/web/fr/tools/navigation/myaudi/fr/privacy-policy.html",
+      "select": {
+        "startBefore": "h1",
+        "endAfter": ".nm-module"
+      }
+    }
+  }
+}

--- a/declarations/My Citroen.json
+++ b/declarations/My Citroen.json
@@ -1,0 +1,15 @@
+{
+  "name": "MyCitroën",
+  "documents": {
+    "Privacy Policy": {
+      "executeClientScripts": true,
+      "fetch": "https://ac-mym.servicesgp.mpsa.com/webview/gdpr/privacy?culture=fr-FR",
+      "select": "body"
+    },
+    "Terms of Service": {
+      "executeClientScripts": true,
+      "fetch": "https://ac-mym.servicesgp.mpsa.com/webview/cgu?culture=fr-FR",
+      "select": "body"
+    }
+  }
+}

--- a/declarations/My Land Rover InControl.json
+++ b/declarations/My Land Rover InControl.json
@@ -1,0 +1,10 @@
+{
+  "name": "My Land Rover InControl",
+  "documents": {
+    "Privacy Policy": {
+      "executeClientScripts": true,
+      "fetch": "https://incontrol.landrover.com/jlr-portal-owner-web/about/privacy-policy/FRA",
+      "select": "#legal-doc-content > div.WordSection1"
+    }
+  }
+}

--- a/declarations/My Volkswagen.json
+++ b/declarations/My Volkswagen.json
@@ -1,0 +1,12 @@
+{
+  "name": "My Volkswagen",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "https://www.volkswagen.fr/fr/footer/mentions-legales.html",
+      "select": {
+        "startBefore": "#accordionitem_copy_head",
+        "endBefore": "#accordionitem_copy_c_head"
+      }
+    }
+  }
+}

--- a/declarations/MyDS.json
+++ b/declarations/MyDS.json
@@ -1,0 +1,10 @@
+{
+  "name": "MyDS",
+  "documents": {
+    "Privacy Policy": {
+      "executeClientScripts": true,
+      "fetch": "https://ds-mym.servicesgp.mpsa.com/webview/gdpr/privacy?culture=fr-FR",
+      "select": "body"
+    }
+  }
+}

--- a/declarations/MyPeugeot.json
+++ b/declarations/MyPeugeot.json
@@ -1,0 +1,15 @@
+{
+  "name": "MyPeugeot",
+  "documents": {
+    "Privacy Policy": {
+      "executeClientScripts": true,
+      "fetch": "https://ap-mym.servicesgp.mpsa.com/webview/gdpr/privacy?culture=fr-FR",
+      "select": "body"
+    },
+    "Terms of Service": {
+      "executeClientScripts": true,
+      "fetch": "https://ap-mym.servicesgp.mpsa.com/webview/cgu?culture=fr-FR",
+      "select": "body"
+    }
+  }
+}

--- a/declarations/Nissan Connect.json
+++ b/declarations/Nissan Connect.json
@@ -1,0 +1,8 @@
+{
+  "name": "Nissan Connect",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://www.nissan.fr/content/dam/Nissan/nissan_europe/services/Ownership/nissanconnect_services_2021/terms_and_conditions_door_to_door/privacy-policy-for-nissan-connect-door-to-door-navigation-fr-final.pdf"
+    }
+  }
+}

--- a/declarations/Renault Group.json
+++ b/declarations/Renault Group.json
@@ -1,0 +1,15 @@
+{
+  "name": "Renault Group",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://www.renault.fr/donnees-personnelles.html",
+      "select": [
+        "#Page h1",
+        "#Page > div[class='EditorialContentZone']"
+      ],
+      "remove": [
+        "img"
+      ]
+    }
+  }
+}

--- a/declarations/SEAT CONNECT.json
+++ b/declarations/SEAT CONNECT.json
@@ -1,0 +1,9 @@
+{
+  "name": "SEAT CONNECT",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://consent.vwgroup.io/consent/v1/texts/SEATConnect/fr/fr/dataPrivacy/latest/html",
+      "select": "body"
+    }
+  }
+}

--- a/declarations/Skoda Connect.json
+++ b/declarations/Skoda Connect.json
@@ -1,0 +1,9 @@
+{
+  "name": "Škoda Connect",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://consent.vwgroup.io/consent/v1/texts/SkodaConnect/be/fr/PrivacyPolicy/latest/html",
+      "select": "body"
+    }
+  }
+}

--- a/declarations/Skoda ID.json
+++ b/declarations/Skoda ID.json
@@ -1,0 +1,13 @@
+{
+  "name": "Škoda ID",
+  "documents": {
+    "Privacy Policy": {
+      "executeClientScripts": true,
+      "fetch": "https://skodaid.vwgroup.io/data-privacy",
+      "select": {
+        "startBefore": "h1",
+        "endBefore": ".button"
+      }
+    }
+  }
+}

--- a/declarations/Suzuki Connect.json
+++ b/declarations/Suzuki Connect.json
@@ -1,0 +1,10 @@
+{
+  "name": "Suzuki Connect",
+  "documents": {
+    "Privacy Policy": {
+      "executeClientScripts": true,
+      "fetch": "https://wb01cs.sc.pre-eur.connect.suzuki/portal/gpt?type=policy&country=FR",
+      "select": ".service-policies-block"
+    }
+  }
+}

--- a/declarations/Tesla.json
+++ b/declarations/Tesla.json
@@ -1,0 +1,12 @@
+{
+  "name": "Tesla",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://www.tesla.com/fr_fr/legal/privacy",
+      "select": {
+        "startBefore": ".tds-shell h1",
+        "endBefore": ".tds-shell footer"
+      }
+    }
+  }
+}

--- a/declarations/Volkswagen Group France.json
+++ b/declarations/Volkswagen Group France.json
@@ -1,0 +1,12 @@
+{
+  "name": "Volkswagen Group France",
+  "documents": {
+    "Privacy Policy": {
+      "fetch": "https://www.volkswagen.fr/fr/footer/politique-de-confidentialite.html",
+      "select": {
+        "startBefore": ".StyledMainContentWrapper-hViDYX h1",
+        "endBefore": "div.StyledSkipLinkTargetWrapper-TTkYZ footer"
+      }
+    }
+  }
+}

--- a/declarations/Volvo Cars.json
+++ b/declarations/Volvo Cars.json
@@ -1,0 +1,13 @@
+{
+  "name": "Volvo Cars",
+  "documents": {
+    "Privacy Policy": {
+      "executeClientScripts": true,
+      "fetch": "https://www.volvocars.com/fr/legal/privacy/privacy-car",
+      "select": {
+        "startBefore": "h1",
+        "endBefore": "#vcc-site-footer"
+      }
+    }
+  }
+}

--- a/declarations/myOpel.json
+++ b/declarations/myOpel.json
@@ -1,0 +1,10 @@
+{
+  "name": "myOpel",
+  "documents": {
+    "Privacy Policy": {
+      "executeClientScripts": true,
+      "fetch": "https://op-mym.servicesgp.mpsa.com/webview/gdpr/privacy?culture=fr-FR",
+      "select": "body"
+    }
+  }
+}


### PR DESCRIPTION
Hi 👋

Please find in this PR the privacy policies (and some terms of service) for car manufacturers / car apps.

- Some sites require the use of Puppeteer (javascript needed to render doc),
- Some sites (those hosted by `servicesgp.mpsa.com` : My Citroen, myOpel, MyPeugeot and MyDS) have a SSL certificates issue. A simple fix is to use Puppeteer. The trade-off between simplicity/maintainability and computing-cost seemed (to us) in favor of this solution (instead of messing with these particular certificates). Don't hesitate to suggest another solution.

Thanks ! 🚗